### PR TITLE
fix: cannot extend request/response

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,11 @@ declare module 'async-express-mw' {
 
   function asyncMw(
     fn: (
-      req: Partial<Request>,
-      res: Partial<Response>,
+      req: Request & Record<any, any>,
+      res: Response & Record<any, any>,
       ...next: [NextFunction]
-    ) => Promise<typeof fn>
-  ): Promise<void>;
+    ) => any
+  ): any;
 
   export = asyncMw;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-express-mw",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Wrapper to allow async express handlers with error catching",
   "main": "index.js",
   "types": "index.d.ts",
@@ -14,7 +14,10 @@
     "express",
     "middleware"
   ],
-  "author": "lteacher",
+  "contributors": [
+    "lteacher",
+    "krsbx"
+  ],
   "license": "MIT",
   "dependencies": {
     "@types/express": "^4.17.13"


### PR DESCRIPTION
in the previous PR, turns out it gave an error if we use the module with typescript saying the request or the response can't be extends, to fix that we need to add a loosetype that can accept any key, but not losing the other key like body and params, etc
